### PR TITLE
Fix abbreviation formatting

### DIFF
--- a/ctl/scripts/sample-fn.sql
+++ b/ctl/scripts/sample-fn.sql
@@ -49,12 +49,12 @@ BEGIN
             local_addrs_sql = ''
                 'WITH sample AS ('
                 ' SELECT random(), a.hash, a.point, a.unit, a.number, a.street, a.city, a.district, a.region, a.postcode, a.tract_id, a.blkgrpce'
-                ' FROM oa_%I a '
+                ' FROM %I a '
                 ' WHERE a.tract_id = $1'
                 ')'
                 ' INSERT INTO local_addrs(r, hash, point, unit, number, street, city, district, region, postcode, tract_id, blkgrpce)'
                 ' SELECT s.* FROM sample s WHERE ST_Contains($2, s.point)';
-            EXECUTE format(local_addrs_sql, abbr) USING tcand.tract_id, gpart.p;
+            EXECUTE format(local_addrs_sql, format('oa_%s', abbr)) USING tcand.tract_id, gpart.p;
         END LOOP;
     END LOOP;
 


### PR DESCRIPTION
This will fix #18 for some cases, but not all identified.

Specifically addresses in Indiana and Oregon, and adjacent areas like Chicago.

Something different is happening in Arizona, and I haven't had a chance to look into it closely.


Issue is that in the custom pg/psql function that does the sampling, an optimization is to query against the state partition of the addresses table directly, like `oa_[xx]`, instead of incurring the overhead of querying against `oa` and letting postgres find the correct partition, which is slower. So, when we see we're querying for addresses in places like `oregon` or `indiana` we try to query the partitions `oa_or` or `oa_in`. Unfortunately, the pg/psql statement used to generate the partition name was formatting with `%I`, which quotes SQL keywords like `"in"` and `"or"` --- so instead of querying against `oa_or` we generate the query `oa_"or"` which is invalid.

Fixed by generating the table name separately with the unsafe `format("oa_%s", abbr)`, and then safely formatting that entire result into the sampling query with `%I`.

Chicago was affected by this as well because it borders Indiana and so we end up querying addresses in Indiana as part of the rough filter.